### PR TITLE
change string literal style to double_quotes

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -25,6 +25,9 @@ Style/CaseEquality:
 Style/Next:
     Enabled: false
 
+Style/StringLiterals:
+    EnforcedStyle: double_quotes
+
 Layout/ParameterAlignment:
     EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
This is a bit painful as I have been switching the style in rock's
ruby packages to the single_quotes style, but the reason actually
stems from all that work. Single quotes end up pretty inconsistent
with very little benefit.

First: you've got strings with single quotes and strings with
double quotes. I have yet to see a case where the single quotes
really help readability. The interpolation syntax `#{}` is
highlighted by editors, which make it easy to spot.

Second: you are supposed to use single quotes whenever there
isn't an interpolation. But that's except when the string
already has a single quote in it.

Third: the default style forces you to have different
single/double quotes in multi-line strings. There's a setting for
that, but then why not just stick to double quotes ?